### PR TITLE
入室時のLINE通知機能を実装

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -11,4 +11,10 @@ module.exports = {
     buildEslintCommand,
     'prettier --write',
   ],
+  '*.js': (files) => {
+    const cwd = process.cwd()
+    const relativePaths = files.map((file) => path.relative(cwd, file))
+
+    return `eslint --fix ${relativePaths.join(' ')}`
+  },
 }

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ const nextConfig = {
   images: {
     domains: ['localhost'], // 画像を置いているドメイン
   },
+  experimental: {
+    serverActions: true,
+  },
 }
 
 module.exports = nextConfig

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,3 +1,5 @@
+'use server'
+
 export const sendLineNotification = async (message: string): Promise<void> => {
   const accessToken = process.env.NEXT_PUBLIC_LINE_NOTIFY_ACCESS_TOKEN
   const url = 'https://notify-api.line.me/api/notify'

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,21 @@
+export const sendLineNotification = async (message: string): Promise<void> => {
+  const accessToken = process.env.NEXT_PUBLIC_LINE_NOTIFY_ACCESS_TOKEN
+  const url = 'https://notify-api.line.me/api/notify'
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: `message=${message}`,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Error: ${response.status}`)
+    }
+  } catch (error) {
+    console.error('LINE Notify API error:', error)
+  }
+}

--- a/src/app/features/top/RecordStatusModal.tsx
+++ b/src/app/features/top/RecordStatusModal.tsx
@@ -124,7 +124,9 @@ ${loginUserData.name}がHarborsに入室したよ！
 場所：${placesData[formData.placeId - 1].place}
 帰宅予定：${formData.scheduledTimeToLeave}
 ステータス：${workingStatusesData[formData.workingStatusId - 1].status}
-一言：${formData.comment}`
+一言：${formData.comment}
+https://at-at-frontend.vercel.app/
+`
     await sendLineNotification(notificationMessage)
   }
 

--- a/src/app/features/top/RecordStatusModal.tsx
+++ b/src/app/features/top/RecordStatusModal.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { LoadingOverlay } from "@/components/common/LoadingOverlay";
-import { createStatuses } from "@/services/createStatuses";
-import { getUsersWithTodayStatuses } from "@/services/getUsersWithTodayStatuses";
-import { putStatuses } from "@/services/putStatuses";
-import { Place, User, WorkingStatus } from "@/types/supabase";
-import { FC, useState } from "react";
-import { useForm } from "react-hook-form";
+import { FC, useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { sendLineNotification } from '@/app/api/notifications/route'
+import { LoadingOverlay } from '@/components/common/LoadingOverlay'
+import { createStatuses } from '@/services/createStatuses'
+import { getUsersWithTodayStatuses } from '@/services/getUsersWithTodayStatuses'
+import { putStatuses } from '@/services/putStatuses'
+import { Place, User, WorkingStatus } from '@/types/supabase'
 
 type Props = {
-  loginUserData: User;
-  placesData: Place[];
-  workingStatusesData: WorkingStatus[];
+  loginUserData: User
+  placesData: Place[]
+  workingStatusesData: WorkingStatus[]
   isModalOpened: boolean
   setIsModalOpened: React.Dispatch<React.SetStateAction<boolean>>
   setIsEntered: React.Dispatch<React.SetStateAction<boolean>>
@@ -20,23 +22,26 @@ type Props = {
 
 export const RecordStatusModal: FC<Props> = ({
   loginUserData,
-    placesData,
-    workingStatusesData,
-    isModalOpened,
-    setIsModalOpened,
-    setIsEntered,
-    setUsersData
-  }: Props) => {
+  placesData,
+  workingStatusesData,
+  isModalOpened,
+  setIsModalOpened,
+  setIsEntered,
+  setUsersData,
+}: Props) => {
   const [onLoading, setOnLoading] = useState(false)
-    const todayStatusRecord = loginUserData.statuses;
-    const today = new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
-    const dateParts = today.split(' ')[0].split('/');
-    const formattedDate = `${dateParts[0]}-${dateParts[1].padStart(2, '0')}-${dateParts[2].padStart(2, '0')}`;
+  const todayStatusRecord = loginUserData.statuses
+  const today = new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })
+  const dateParts = today.split(' ')[0].split('/')
+  const formattedDate = `${dateParts[0]}-${dateParts[1].padStart(
+    2,
+    '0',
+  )}-${dateParts[2].padStart(2, '0')}`
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm();
+  } = useForm()
 
   const validationRules = {
     placeId: {
@@ -69,115 +74,191 @@ export const RecordStatusModal: FC<Props> = ({
     },
   }
 
-  const onSubmit = async(formData: any) => {
+  const onSubmit = async (formData: any) => {
     setOnLoading(true)
 
-    if(todayStatusRecord.length > 0) {
+    if (todayStatusRecord.length > 0) {
       // statusesに今日のレコードがある場合はupdate
       const reqBodyData = JSON.stringify({
         userId: loginUserData.id,
         date: formattedDate,
         type: 'in',
-        ...formData
+        ...formData,
       })
 
       const resData = await putStatuses(reqBodyData)
 
-      if(resData.error) {
-        alert("エラーが発生しました。")
+      if (resData.error) {
+        alert('エラーが発生しました。')
         setOnLoading(false)
         return
       }
-    }else {
+    } else {
       // statusesに今日のレコードがない場合はcreate
       const reqBodyData = JSON.stringify({
         userId: loginUserData.id,
         date: formattedDate,
-        ...formData
+        ...formData,
       })
 
       const resData = await createStatuses(reqBodyData)
 
-      if(resData.error) {
-        alert("エラーが発生しました。")
+      if (resData.error) {
+        alert('エラーが発生しました。')
         setOnLoading(false)
         return
       }
     }
 
-    const usersWithStatusesDataRes = await getUsersWithTodayStatuses();
+    const usersWithStatusesDataRes = await getUsersWithTodayStatuses()
     setUsersData(usersWithStatusesDataRes)
     setIsEntered(true)
     setIsModalOpened(false)
     setOnLoading(false)
-  };
+
+    // LINE通知
+    const notificationMessage = `
+${loginUserData.name}がHarborsに入室したよ！
+
+日付：${formattedDate}
+場所：${formData.placeId}
+帰宅予定：${formData.scheduledTimeToLeave}
+ステータス：${formData.workingStatusId}
+一言：${formData.comment}
+    `
+    await sendLineNotification(notificationMessage)
+  }
 
   return (
     <>
-      {isModalOpened &&
-        <form className="fixed top-1/2 left-1/2 p-10 transform -translate-x-1/2 -translate-y-1/2 bg-white shadow-2xl shadow-gray-700/50 text-black rounded" onSubmit={handleSubmit(onSubmit)}>
+      {isModalOpened && (
+        <form
+          className="fixed top-1/2 left-1/2 p-10 transform -translate-x-1/2 -translate-y-1/2 bg-white shadow-2xl shadow-gray-700/50 text-black rounded"
+          onSubmit={handleSubmit(onSubmit)}
+        >
           <div className="mb-5">
-            <label htmlFor="placeId" className="block pl-1 mb-2 text-blue-500 font-bold">場所</label>
+            <label
+              htmlFor="placeId"
+              className="block pl-1 mb-2 text-blue-500 font-bold"
+            >
+              場所
+            </label>
             <select
               id="placeId"
-              defaultValue={todayStatusRecord.length > 0 ? todayStatusRecord[0].places.id : ''}
+              defaultValue={
+                todayStatusRecord.length > 0
+                  ? todayStatusRecord[0].places.id
+                  : ''
+              }
               {...register('placeId', validationRules.placeId)}
               className="p-3 w-64 bg-gray-100 rounded"
             >
               {placesData.map((place) => (
-                <option key={place.id} value={place.id}>{place.place}</option>
+                <option key={place.id} value={place.id}>
+                  {place.place}
+                </option>
               ))}
             </select>
-            {errors.placeId?.message && <p className="mt-1 text-red-600 text-sm">{errors.placeId.message.toString()}</p>}
+            {errors.placeId?.message && (
+              <p className="mt-1 text-red-600 text-sm">
+                {errors.placeId.message.toString()}
+              </p>
+            )}
           </div>
           <div className="mb-5">
-            <label htmlFor="scheduledTimeToLeave" className="block pl-1 mb-2 text-blue-500 font-bold">帰宅予定</label>
+            <label
+              htmlFor="scheduledTimeToLeave"
+              className="block pl-1 mb-2 text-blue-500 font-bold"
+            >
+              帰宅予定
+            </label>
             <input
               id="scheduledTimeToLeave"
-              defaultValue={todayStatusRecord.length > 0 ? todayStatusRecord[0].scheduled_time_to_leave : ''}
-              {...register('scheduledTimeToLeave', validationRules.scheduledTimeToLeave)}
+              defaultValue={
+                todayStatusRecord.length > 0
+                  ? todayStatusRecord[0].scheduled_time_to_leave
+                  : ''
+              }
+              {...register(
+                'scheduledTimeToLeave',
+                validationRules.scheduledTimeToLeave,
+              )}
               type="time"
               className="p-3 w-64 bg-gray-100 rounded"
             />
-            {errors.scheduledTimeToLeave?.message && <p className="mt-1 text-red-600 text-sm">{errors.scheduledTimeToLeave.message.toString()}</p>}
+            {errors.scheduledTimeToLeave?.message && (
+              <p className="mt-1 text-red-600 text-sm">
+                {errors.scheduledTimeToLeave.message.toString()}
+              </p>
+            )}
           </div>
           <div className="mb-5">
-            <label htmlFor="workingStatusId" className="block pl-1 mb-2 text-blue-500 font-bold">ステータス</label>
+            <label
+              htmlFor="workingStatusId"
+              className="block pl-1 mb-2 text-blue-500 font-bold"
+            >
+              ステータス
+            </label>
             <select
               id="workingStatusId"
-              defaultValue={todayStatusRecord.length > 0 ? todayStatusRecord[0].working_statuses.id : ''}
+              defaultValue={
+                todayStatusRecord.length > 0
+                  ? todayStatusRecord[0].working_statuses.id
+                  : ''
+              }
               {...register('workingStatusId', validationRules.workingStatusId)}
               className="p-3 w-64 bg-gray-100 rounded"
             >
               {workingStatusesData.map((workingStatus) => (
-                <option key={workingStatus.id} value={workingStatus.id}>{workingStatus.status}</option>
+                <option key={workingStatus.id} value={workingStatus.id}>
+                  {workingStatus.status}
+                </option>
               ))}
             </select>
-            {errors.workingStatusId?.message && <p className="mt-1 text-red-600 text-sm">{errors.workingStatusId.message.toString()}</p>}
+            {errors.workingStatusId?.message && (
+              <p className="mt-1 text-red-600 text-sm">
+                {errors.workingStatusId.message.toString()}
+              </p>
+            )}
           </div>
           <div className="mb-5">
-            <label htmlFor="comment" className="block pl-1 mb-2 text-blue-500 font-bold">
+            <label
+              htmlFor="comment"
+              className="block pl-1 mb-2 text-blue-500 font-bold"
+            >
               一言
               <span className="ml-2 text-gray-500 text-xs">※10文字以内</span>
             </label>
             <input
               id="comment"
-              defaultValue={todayStatusRecord.length > 0 ? todayStatusRecord[0].comment : ''}
+              defaultValue={
+                todayStatusRecord.length > 0 ? todayStatusRecord[0].comment : ''
+              }
               {...register('comment', validationRules.comment)}
               type="text"
               className="p-3 w-64 bg-gray-100 rounded"
               maxLength={10}
             />
-            {errors.comment?.message && <p className="mt-1 text-red-600 text-sm">{errors.comment.message.toString()}</p>}
+            {errors.comment?.message && (
+              <p className="mt-1 text-red-600 text-sm">
+                {errors.comment.message.toString()}
+              </p>
+            )}
           </div>
           <div className="flex mt-10 justify-end">
-            <button type="submit" className="py-3 px-8 bg-blue-500 text-white rounded">{todayStatusRecord.length === 0 || todayStatusRecord[0].is_entered == false ? '入室' : '更新'}</button>
+            <button
+              type="submit"
+              className="py-3 px-8 bg-blue-500 text-white rounded"
+            >
+              {todayStatusRecord.length === 0 ||
+              todayStatusRecord[0].is_entered == false
+                ? '入室'
+                : '更新'}
+            </button>
           </div>
         </form>
-      }
-      {onLoading &&
-        <LoadingOverlay />
-      }
+      )}
+      {onLoading && <LoadingOverlay />}
     </>
   )
 }

--- a/src/app/features/top/RecordStatusModal.tsx
+++ b/src/app/features/top/RecordStatusModal.tsx
@@ -121,11 +121,10 @@ export const RecordStatusModal: FC<Props> = ({
 ${loginUserData.name}がHarborsに入室したよ！
 
 日付：${formattedDate}
-場所：${formData.placeId}
+場所：${placesData[formData.placeId - 1].place}
 帰宅予定：${formData.scheduledTimeToLeave}
-ステータス：${formData.workingStatusId}
-一言：${formData.comment}
-    `
+ステータス：${workingStatusesData[formData.workingStatusId - 1].status}
+一言：${formData.comment}`
     await sendLineNotification(notificationMessage)
   }
 

--- a/src/app/features/top/RecordStatusModal.tsx
+++ b/src/app/features/top/RecordStatusModal.tsx
@@ -122,7 +122,7 @@ ${loginUserData.name}がHarborsに入室したよ！
 
 日付：${formattedDate}
 場所：${placesData[formData.placeId - 1].place}
-帰宅予定：${formData.scheduledTimeToLeave}
+帰宅予定：${formData.scheduledTimeToLeave.substring(0, 5)}
 ステータス：${workingStatusesData[formData.workingStatusId - 1].status}
 一言：${formData.comment}
 https://at-at-frontend.vercel.app/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 説明
<!-- どのような背景で何のために実装するのか？ -->
アプリを開かなくてもLINE上でだれがいつHarborsに入室したか知ることができる。その効果として、@_@とユーザーの接点を増やすことができ、@_@の使用頻度が増加することが予想される。

## 変更内容
<!-- 変更内容、変更の仕組み、および潜在的な副作用や制限についての詳細な説明を書きます。解決している問題または実装している機能に関する情報を必ず含めてください。 -->
src/app/apiの直下にnotifications/route.tsを作成し、その中でLINE通知を行う関数sendLineNotificationを定義した。
上記の関数はsrc/app/features/top/RecordStatusModal.tsxで呼び出している（118行目から130行目の変更）。

なお、LINE通知を行う関数を実装する過程で、サーバーアクションを有効化する必要が生じたため、next.config.jsに変更を加えたが、同ファイルの変更をコミットするために、.lintstagedrc.js及びtsconfig.jsonも修正した。

## スクリーンショット
<!-- 変更に視覚要素が含まれる場合、またはユーザー インターフェースに影響を与える場合は、レビュー担当者が視覚的な影響をよりよく理解できるようにスクリーンショットを含めます。 -->
<!-- API定義の場合は、OpenAPIのキャプチャ -->
<!-- API開発の場合は、レスポンス証跡のキャプチャ -->
UIに変更なし
<img width="949" alt="スクリーンショット 2023-12-27 095128" src="https://github.com/atsuh1r0/at_at/assets/107542816/c16d0fc2-f732-46a4-9bb2-4eb155892ff3">

## 関連リンク
<!-- レビュー担当者が作業のコンテキストを理解しやすくするために、課題トラッカー、機能リクエスト、設計ドキュメントなどの関連リンクを提供します。 -->
<!-- 対応画面のfigmaリンクなど -->

## 確認したこと
<!-- テスト内容 -->
入室時の情報（場所や帰宅予定等）を変更した際は、変更に応じた通知がなされる。
※現在の仕様では、入室時だけでなくラベル変更時も通知されるようになっている。
![S__82288644](https://github.com/atsuh1r0/at_at/assets/107542816/a9b6addc-fa2b-4101-81ef-99a7e044f94e)


## 備考
<!-- 証跡など -->
本番環境に移行する際には、.env.localのトークンをPOSSE②全体グループ用のトークンに差し替える必要がある。

## 確認事項
